### PR TITLE
Small fixes refactors

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -66,7 +66,6 @@ def create_app(run_as_server=True):
     setup_csrf_protection(app)
     setup_debug_toolbar(app)
     setup_jinja2_filters(app)
-    setup_queues(app)
     setup_newsletter(app)
     return app
 
@@ -421,10 +420,6 @@ def setup_ratelimits(app):
     global ratelimits
     ratelimits['LIMIT'] = app.config['LIMIT']
     ratelimits['PER'] = app.config['PER']
-
-def setup_queues(app):
-    global queues
-    queues['webhook'] = Queue('high', connection=sentinel.master)
 
 
 def setup_cache_timeouts(app):

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -47,10 +47,6 @@ def create_app(run_as_server=True):
     login_manager.setup_app(app)
     setup_babel(app)
     setup_markdown(app)
-    # Set up Gravatar for users
-    setup_gravatar(app)
-    #gravatar = Gravatar(app, size=100, rating='g', default='mm',
-                        #force_default=False, force_lower=False)
     setup_db(app)
     setup_repositories()
     setup_exporter(app)
@@ -161,10 +157,6 @@ def setup_repositories():
     blog_repo = BlogRepository(db)
     task_repo = TaskRepository(db)
     auditlog_repo = AuditlogRepository(db)
-
-
-def setup_gravatar(app):
-    gravatar.init_app(app)
 
 
 def setup_error_email(app):

--- a/pybossa/extensions.py
+++ b/pybossa/extensions.py
@@ -11,14 +11,13 @@ The objects are:
     * google: for Google signin
     * misaka: for app.long_description markdown support,
     * babel: for i18n support,
-    * gravatar: for Gravatar support,
     * uploader: for file uploads support,
     * csrf: for CSRF protection
     * newsletter: for subscribing users to Mailchimp newsletter
 
 """
 __all__ = ['sentinel', 'db', 'signer', 'mail', 'login_manager', 'facebook',
-           'twitter', 'google', 'misaka', 'babel', 'gravatar', 'uploader',
+           'twitter', 'google', 'misaka', 'babel', 'uploader',
            'csrf', 'timeouts', 'debug_toolbar', 'ratelimits', 'queues',
            'user_repo', 'project_repo', 'task_repo', 'blog_repo', 'newsletter']
 
@@ -70,11 +69,6 @@ misaka = Misaka()
 # Babel
 from flask.ext.babel import Babel
 babel = Babel()
-
-# Gravatar
-from flask.ext.gravatar import Gravatar
-gravatar = Gravatar(size=100, rating='g', default='mm',
-                    force_default=False, force_lower=False)
 
 # Uploader
 uploader = None

--- a/pybossa/extensions.py
+++ b/pybossa/extensions.py
@@ -18,8 +18,8 @@ The objects are:
 """
 __all__ = ['sentinel', 'db', 'signer', 'mail', 'login_manager', 'facebook',
            'twitter', 'google', 'misaka', 'babel', 'uploader', 'debug_toolbar',
-           'csrf', 'timeouts', 'ratelimits', 'queues', 'auditlog_repo',
-           'user_repo', 'project_repo', 'task_repo', 'blog_repo', 'newsletter']
+           'csrf', 'timeouts', 'ratelimits', 'user_repo', 'project_repo',
+           'task_repo', 'blog_repo', 'auditlog_repo', 'newsletter']
 
 # CACHE
 from pybossa.sentinel import Sentinel
@@ -87,9 +87,6 @@ timeouts = dict()
 
 # Ratelimits
 ratelimits = dict()
-
-# Queues
-queues = dict()
 
 # Newsletter
 from newsletter import Newsletter

--- a/pybossa/extensions.py
+++ b/pybossa/extensions.py
@@ -17,8 +17,8 @@ The objects are:
 
 """
 __all__ = ['sentinel', 'db', 'signer', 'mail', 'login_manager', 'facebook',
-           'twitter', 'google', 'misaka', 'babel', 'uploader',
-           'csrf', 'timeouts', 'debug_toolbar', 'ratelimits', 'queues',
+           'twitter', 'google', 'misaka', 'babel', 'uploader', 'debug_toolbar',
+           'csrf', 'timeouts', 'ratelimits', 'queues', 'auditlog_repo',
            'user_repo', 'project_repo', 'task_repo', 'blog_repo', 'newsletter']
 
 # CACHE
@@ -35,6 +35,7 @@ user_repo = None
 project_repo = None
 blog_repo = None
 task_repo = None
+auditlog_repo = None
 
 # Signer
 from pybossa.signer import Signer

--- a/pybossa/sentinel/__init__.py
+++ b/pybossa/sentinel/__init__.py
@@ -1,10 +1,12 @@
-from redis import sentinel
+from redis import sentinel, StrictRedis
 
 
 class Sentinel(object):
 
     def __init__(self, app=None):
         self.app = app
+        self.master = StrictRedis()
+        self.slave = self.master
         if app is not None: # pragma: no cover
             self.init_app(app)
 

--- a/setup.py
+++ b/setup.py
@@ -6,7 +6,6 @@ requirements = [
     "blinker>=1.3, <2.0",
     "Flask-Babel>=0.9, <1.0",
     "Flask-Cache>=0.12, <1.0",
-    "Flask-Gravatar>=0.4.1, <1.0",
     "flask-heroku>=0.1.8, <1.0",
     "Flask-Login",                      # was pinned to Flask-Login==0.2.3 in the past. GitHub version 3.0+ is used now.
     "Flask-Mail>=0.9.0, <1.0",

--- a/test/factories/__init__.py
+++ b/test/factories/__init__.py
@@ -16,20 +16,10 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.
 
-from pybossa.core import db
+from pybossa.core import (db, user_repo, project_repo, task_repo, blog_repo,
+    auditlog_repo)
 
 import factory
-
-from pybossa.repositories import UserRepository
-from pybossa.repositories import ProjectRepository
-from pybossa.repositories import BlogRepository
-from pybossa.repositories import TaskRepository
-from pybossa.repositories import AuditlogRepository
-user_repo = UserRepository(db)
-project_repo = ProjectRepository(db)
-blog_repo = BlogRepository(db)
-task_repo = TaskRepository(db)
-auditlog_repo = AuditlogRepository(db)
 
 
 def reset_all_pk_sequences():

--- a/test/factories/__init__.py
+++ b/test/factories/__init__.py
@@ -16,10 +16,20 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.
 
-from pybossa.core import (db, user_repo, project_repo, task_repo, blog_repo,
-    auditlog_repo)
+from pybossa.core import db
 
 import factory
+
+from pybossa.repositories import UserRepository
+from pybossa.repositories import ProjectRepository
+from pybossa.repositories import BlogRepository
+from pybossa.repositories import TaskRepository
+from pybossa.repositories import AuditlogRepository
+user_repo = UserRepository(db)
+project_repo = ProjectRepository(db)
+blog_repo = BlogRepository(db)
+task_repo = TaskRepository(db)
+auditlog_repo = AuditlogRepository(db)
 
 
 def reset_all_pk_sequences():

--- a/test/factories/auditlog_factory.py
+++ b/test/factories/auditlog_factory.py
@@ -20,8 +20,6 @@ from pybossa.model.auditlog import Auditlog
 from . import BaseFactory, factory, auditlog_repo
 
 
-app = factory.SubFactory('factories.AppFactory')
-
 class AuditlogFactory(BaseFactory):
     class Meta:
         model = Auditlog

--- a/test/factories/auditlog_factory.py
+++ b/test/factories/auditlog_factory.py
@@ -31,6 +31,10 @@ class AuditlogFactory(BaseFactory):
         return log
 
     id = factory.Sequence(lambda n: n)
+    app_id = 1
+    app_short_name = 'app'
+    user_id = 1
+    user_name = 'example user'
     action = 'update'
     caller = 'web'
     attribute = 'attribute'

--- a/test/test_authorization/test_auditlog_auth.py
+++ b/test/test_authorization/test_auditlog_auth.py
@@ -63,7 +63,7 @@ class TestAuditlogAuthorization(Test):
     @patch('pybossa.auth.current_user', new=mock_pro)
     @patch('pybossa.auth.auditlog.current_user', new=mock_pro)
     def test_pro_user_can_read_auditlog(self):
-        """Test pro users can read auditlogs"""
+        """Test pro users can read auditlogs from owned projects"""
 
         owner = UserFactory.create_batch(2, pro=True)[1]
         app = AppFactory.create(owner=owner)
@@ -71,6 +71,19 @@ class TestAuditlogAuthorization(Test):
 
         assert self.mock_pro.id == app.owner_id
         assert_not_raises(Exception, getattr(require, 'auditlog').read, log)
+
+
+    @patch('pybossa.auth.current_user', new=mock_pro)
+    @patch('pybossa.auth.auditlog.current_user', new=mock_pro)
+    def test_pro_user_cannot_read_auditlog(self):
+        """Test pro users cannot read auditlogs from non-owned projects"""
+
+        users = UserFactory.create_batch(2, pro=True)
+        app = AppFactory.create(owner=users[0])
+        log = AuditlogFactory.create(app_id=app.id)
+
+        assert self.mock_pro.id != app.owner_id
+        assert_raises(Forbidden, getattr(require, 'auditlog').read, log)
 
 
     @patch('pybossa.auth.current_user', new=mock_admin)

--- a/test/test_forms.py
+++ b/test/test_forms.py
@@ -20,8 +20,8 @@ from wtforms import ValidationError
 from nose.tools import raises
 from flask import current_app
 
-from pybossa.forms.forms import RegisterForm, LoginForm
 from default import Test, db, with_context
+from pybossa.forms.forms import RegisterForm, LoginForm
 from pybossa.forms import validator
 from pybossa.repositories import UserRepository
 from factories import UserFactory

--- a/test/test_model/test_webhooks.py
+++ b/test/test_model/test_webhooks.py
@@ -58,7 +58,7 @@ class TestWebHooks(Test):
         assert webhook(None) is False, err_msg
 
     @with_context
-    @patch.dict('pybossa.model.task_run.queues', {'webhook': queue})
+    @patch('pybossa.model.task_run.webhook_queue', new=queue)
     def test_trigger_webhook_without_url(self):
         """Test WEBHOOK is triggered without url."""
         app = AppFactory.create()
@@ -68,7 +68,7 @@ class TestWebHooks(Test):
         queue.reset_mock()
 
     @with_context
-    @patch.dict('pybossa.model.task_run.queues', {'webhook': queue})
+    @patch('pybossa.model.task_run.webhook_queue', new=queue)
     def test_trigger_webhook_with_url_not_completed_task(self):
         """Test WEBHOOK is not triggered for uncompleted tasks."""
         import random
@@ -82,7 +82,7 @@ class TestWebHooks(Test):
 
 
     @with_context
-    @patch.dict('pybossa.model.task_run.queues', {'webhook': queue})
+    @patch('pybossa.model.task_run.webhook_queue', new=queue)
     def test_trigger_webhook_with_url(self):
         """Test WEBHOOK is triggered with url."""
         url = 'http://server.com'

--- a/test/test_mofa.py
+++ b/test/test_mofa.py
@@ -1,9 +1,0 @@
-from factories import AppFactory
-from pybossa.core import db
-from default import Test
-
-class TestMofa(Test):
-    def test_one(self):
-        app = AppFactory.build()
-        print app in db.session
-        assert False

--- a/test/test_mofa.py
+++ b/test/test_mofa.py
@@ -1,0 +1,9 @@
+from factories import AppFactory
+from pybossa.core import db
+from default import Test
+
+class TestMofa(Test):
+    def test_one(self):
+        app = AppFactory.build()
+        print app in db.session
+        assert False

--- a/test/test_repository/test_auditlog_repository.py
+++ b/test/test_repository/test_auditlog_repository.py
@@ -164,7 +164,7 @@ class TestAuditlogRepositoryForProjects(Test):
         """Test save raises a DBIntegrityError if the instance to be saved lacks
         a required value"""
 
-        log = AuditlogFactory.build()
+        log = AuditlogFactory.build(app_id=None)
 
         assert_raises(DBIntegrityError, self.auditlog_repo.save, log)
 


### PR DESCRIPTION
Includes the following changes. Also merged changes from #996 up to 5399cf237be74d1434cbd880575f9f7e9995fb1d

- Remove Gravatar libraries and references to them in both code and templates (merge too PyBossa/crowdcrafting-theme#47 and PyBossa/pybossa-default-theme#55).
- Fix and completes some tests in auditlog authorization module.
- Default Sentinel module to use a normal StrictRedis connection when used outside of an application context.
- Create rq.Queue objects explicitly.