### PR TITLE
Downgrade Pyrax Rackspace uploading module

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -31,7 +31,7 @@ requirements = [
     "sphinx>=1.2.2, <2.0",
     "coverage",
     "mock",
-    "pyrax>=1.9.3, <2.0",
+    "pyrax==1.8.0",
     "pillow>=2.4, <2.5",
     "flask-debugtoolbar>=0.9.0, <1.0",
     "factory_boy>=2.4.1, <2.5",


### PR DESCRIPTION
Newest Pyrax is causing slowdowns currently.
This issue needs investigation.
Downgrade it for now to be on the safe side.