### PR TITLE
Support for LDAP authentication integration 

### DIFF
--- a/doc/customizing.rst
+++ b/doc/customizing.rst
@@ -243,15 +243,15 @@ location, in the retrieved object, of the user's email address), `LDAP_USERNAME_
 in the retrieved object, of the user's fullly qualified LDAP path, to be used for authentication).
 
 
-.. _`LDAP_SERVER`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L58  
-.. _`LDAP_CONNECTION_ACCOUNT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L59
-.. _`LDAP_CONNECTION_PASSWORD`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L60
-.. _`LDAP_BASE_SEARCH_DN`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L61
-.. _`LDAP_SEARCH_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L62  #Your LDAP search string. Add the string ##ACCOUNT_NAME## at the location of your looked up account name
-.. _`LDAP_NAME_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L63  #The LDAP property name you want to use as your name property
-.. _`LDAP_FULLNAME_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L64  #The LDAP property name you want to use as your full name property
-.. _`LDAP_EMAIL_ADDRESS_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L65  #The LDAP property name you want to use as your email property
-.. _`LDAP_USERNAME_PATH`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L66
+.. _`LDAP_SERVER`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L155
+.. _`LDAP_CONNECTION_ACCOUNT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L156
+.. _`LDAP_CONNECTION_PASSWORD`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L157
+.. _`LDAP_BASE_SEARCH_DN`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L158
+.. _`LDAP_SEARCH_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L159
+.. _`LDAP_NAME_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L160
+.. _`LDAP_FULLNAME_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L161
+.. _`LDAP_EMAIL_ADDRESS_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L162
+.. _`LDAP_USERNAME_PATH`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L163
 
 Receiving e-mails with errors
 =============================

--- a/doc/customizing.rst
+++ b/doc/customizing.rst
@@ -228,6 +228,31 @@ them.
 .. _`GOOGLE_CLIENT_SECRET`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L57
 
 
+LDAP
+~~~
+
+If you want to enable LDAP authentication, instead of local authentication, you will need to track down
+LDAP configuration information and copy and paste the following into these variables as appropriate:
+`LDAP_SERVER`_ (the FQDN of your DNS server), `LDAP_CONNECTION_ACCOUNT`_ (the username of an account 
+authorized to query the LDAP server), `LDAP_CONNECTION_PASSWORD`_ (the password of that account),
+`LDAP_BASE_SEARCH_DN`_ (where the system should search for your user objects), `LDAP_SEARCH_OBJECT`_ 
+(LDAP search string. Add the string ##ACCOUNT_NAME## at the location of your looked up account name), 
+`LDAP_NAME_OBJECT`_ (the location, in the retrieved object, of the name field), `LDAP_FULLNAME_OBJECT`_ 
+(the location, in the retrieved object, of the user's full name), `LDAP_EMAIL_ADDRESS_OBJECT`_ (the 
+location, in the retrieved object, of the user's email address), `LDAP_USERNAME_PATH`_ (the location, 
+in the retrieved object, of the user's fullly qualified LDAP path, to be used for authentication).
+
+
+.. _`LDAP_SERVER`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L58  
+.. _`LDAP_CONNECTION_ACCOUNT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L59
+.. _`LDAP_CONNECTION_PASSWORD`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L60
+.. _`LDAP_BASE_SEARCH_DN`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L61
+.. _`LDAP_SEARCH_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L62  #Your LDAP search string. Add the string ##ACCOUNT_NAME## at the location of your looked up account name
+.. _`LDAP_NAME_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L63  #The LDAP property name you want to use as your name property
+.. _`LDAP_FULLNAME_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L64  #The LDAP property name you want to use as your full name property
+.. _`LDAP_EMAIL_ADDRESS_OBJECT`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L65  #The LDAP property name you want to use as your email property
+.. _`LDAP_USERNAME_PATH`: https://github.com/PyBossa/pybossa/blob/master/settings_local.py.tmpl#L66
+
 Receiving e-mails with errors
 =============================
 

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -316,10 +316,8 @@ def setup_external_services(app):
 
     # Enable LDAP if available
     try:  # pragma: no cover
-        if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS__OBJECT'] and app.config['LDAP_USERNAME_PATH']):
+        if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS_OBJECT'] and app.config['LDAP_USERNAME_PATH']):
             ldap.init_app(app)
-            from pybossa.view.ldap import blueprint as ldap_bp
-            app.register_blueprint(ldap_bp, url_prefix='/ldap')
     except Exception as inst: # pragma: no cover
         print type(inst)
         print inst.args

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -316,7 +316,9 @@ def setup_external_services(app):
 
     # Enable LDAP if available
     try:  # pragma: no cover
-        if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS_OBJECT'] and app.config['LDAP_USERNAME_PATH']):
+        if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and 
+           app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and 
+           app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS_OBJECT'] and app.config['LDAP_USERNAME_PATH']):
             ldap.init_app(app)
     except Exception as inst: # pragma: no cover
         print type(inst)

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -314,6 +314,19 @@ def setup_external_services(app):
         log_message = 'Dropbox importer not available: %s' % str(inst)
         app.logger.error(log_message)
 
+    # Enable LDAP if available
+    try:  # pragma: no cover
+        if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS__OBJECT'] and app.config['LDAP_USERNAME_PATH']):
+            ldap.init_app(app)
+            from pybossa.view.ldap import blueprint as ldap_bp
+            app.register_blueprint(ldap_bp, url_prefix='/ldap')
+    except Exception as inst: # pragma: no cover
+        print type(inst)
+        print inst.args
+        print inst
+        print "LDAP signin disabled"
+        log_message = 'LDAP signin disabled: %s' % str(inst)
+        app.logger.error(log_message)
 
 def setup_geocoding(app):
     # Check if app stats page can generate the map

--- a/pybossa/extensions.py
+++ b/pybossa/extensions.py
@@ -20,7 +20,7 @@ __all__ = ['sentinel', 'db', 'signer', 'mail', 'login_manager', 'facebook',
            'twitter', 'google', 'misaka', 'babel', 'uploader', 'debug_toolbar',
            'csrf', 'timeouts', 'ratelimits', 'user_repo', 'project_repo',
            'task_repo', 'blog_repo', 'auditlog_repo', 'newsletter', 'importer',
-           'flickr']
+           'flickr','ldap']
 
 # CACHE
 from pybossa.sentinel import Sentinel
@@ -63,6 +63,9 @@ twitter = Twitter()
 
 from pybossa.util import Google
 google = Google()
+
+from pybossa.util import Ldap
+ldap = Ldap()
 
 # Markdown support
 from flask.ext.misaka import Misaka

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -250,7 +250,8 @@ class Ldap(object):
             self.init_app()
 
     def init_app(self, app):
-        self.base_connection = simpleldap.Connection(app.config['LDAP_SERVER'], dn=app.config['LDAP_CONNECTION_ACCOUNT'], password=app.config['LDAP_CONNECTION_PASSWORD'])
+        self.base_connection = simpleldap.Connection(app.config['LDAP_SERVER'], dn=app.config['LDAP_CONNECTION_ACCOUNT'],
+          password=app.config['LDAP_CONNECTION_PASSWORD'])
 
 def unicode_csv_reader(unicode_csv_data, dialect=csv.excel, **kwargs):
     # This code is taken from http://docs.python.org/library/csv.html#examples

--- a/pybossa/util.py
+++ b/pybossa/util.py
@@ -27,6 +27,7 @@ from flask_oauthlib.client import OAuth
 from flask.ext.login import current_user
 from math import ceil
 import json
+import simpleldap
 
 
 def jsonpify(f):
@@ -241,6 +242,15 @@ class Google(object):
             consumer_key=app.config['GOOGLE_CLIENT_ID'],
             consumer_secret=app.config['GOOGLE_CLIENT_SECRET'])
 
+class Ldap(object):
+
+    def __init__(self, app=None):
+        self.app=app
+        if app is not None: #pragma: no cover
+            self.init_app()
+
+    def init_app(self, app):
+        self.base_connection = simpleldap.Connection(app.config['LDAP_SERVER'], dn=app.config['LDAP_CONNECTION_ACCOUNT'], password=app.config['LDAP_CONNECTION_PASSWORD'])
 
 def unicode_csv_reader(unicode_csv_data, dialect=csv.excel, **kwargs):
     # This code is taken from http://docs.python.org/library/csv.html#examples

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -43,7 +43,7 @@ from flask.ext.babel import gettext
 from sqlalchemy.sql import text
 from pybossa.model.user import User
 from pybossa.core import signer, mail, uploader, sentinel, newsletter, ldap
-from pybossa.util import Pagination, pretty_date
+from pybossa.util import Pagination
 from pybossa.util import get_user_signup_method
 from pybossa.cache import users as cached_users
 from pybossa.cache import apps as cached_apps
@@ -126,8 +126,11 @@ def signin():
         password = form.password.data
         email = form.email.data
         try:
-            if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS_OBJECT'] and app.config['LDAP_USERNAME_PATH']):
-                ldap_response_object = ldap.base_connection.search(app.config['LDAP_SEARCH_OBJECT'].replace("##ACCOUNT_NAME##",email), base_dn=app.config['LDAP_BASE_SEARCH_DN'])[0]
+            if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and 
+               app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and 
+               app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS_OBJECT'] and app.config['LDAP_USERNAME_PATH']):
+                ldap_response_object = ldap.base_connection.search(app.config['LDAP_SEARCH_OBJECT'].replace("##ACCOUNT_NAME##",email), 
+                   base_dn=app.config['LDAP_BASE_SEARCH_DN'])[0]
                 user = user_repo.get_by(name=ldap_response_object[app.config['LDAP_NAME_OBJECT']][0])
                 if user and ldap.base_connection.authenticate(ldap_response_object[app.config['LDAP_USERNAME_PATH']][0], password):
                     msg_1 = gettext("Welcome back") + " " + user.fullname
@@ -139,7 +142,7 @@ def signin():
                     msg_1 = gettext("Welcome to PYBOSSA") + " " + user.fullname
                     flash(msg_1, 'success')
                     return _sign_in_user(user)
-        except:
+        except Exception as inst:
             user = user_repo.get_by(email_addr=email)
             if user and user.check_password(password):
                 msg_1 = gettext("Welcome back") + " " + user.fullname
@@ -208,7 +211,8 @@ def ldap_signup(userobject):
     """
     Registers an LDAP user to the pybossa database
     """
-    account = User(fullname=userobject[app.config['LDAP_FULLNAME_OBJECT']][0], name=userobject[app.config['LDAP_NAME_OBJECT']][0], email_addr=userobject[app.config['LDAP_EMAIL_ADDRESS_OBJECT']][0])
+    account = User(fullname=userobject[app.config['LDAP_FULLNAME_OBJECT']][0], 
+      name=userobject[app.config['LDAP_NAME_OBJECT']][0], email_addr=userobject[app.config['LDAP_EMAIL_ADDRESS_OBJECT']][0])
     user_repo.save(account)
     return account
 

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -30,8 +30,9 @@ from itsdangerous import BadData
 from markdown import markdown
 import json
 import time
+import os
 
-from flask import Blueprint, request, url_for, flash, redirect, abort
+from flask import Blueprint, request, url_for, flash, redirect, abort, Flask
 from flask import render_template, current_app
 from flask.ext.login import login_required, login_user, logout_user, \
     current_user
@@ -41,7 +42,7 @@ import pybossa.model as model
 from flask.ext.babel import gettext
 from sqlalchemy.sql import text
 from pybossa.model.user import User
-from pybossa.core import signer, mail, uploader, sentinel, newsletter
+from pybossa.core import signer, mail, uploader, sentinel, newsletter, ldap
 from pybossa.util import Pagination, pretty_date
 from pybossa.util import get_user_signup_method
 from pybossa.cache import users as cached_users
@@ -62,6 +63,11 @@ blueprint = Blueprint('account', __name__)
 
 mail_queue = Queue('super', connection=sentinel.master)
 
+def configure_app(app):
+    here = os.path.dirname(os.path.abspath(__file__))
+    config_path = os.path.join(os.path.dirname(here), '../settings_local.py')
+    if os.path.exists(config_path): # pragma: no cover
+        app.config.from_pyfile(config_path)
 
 def get_update_feed():
     """Return update feed list."""
@@ -104,6 +110,8 @@ def index(page):
                            title="Community", pagination=pagination,
                            update_feed=update_feed)
 
+app = Flask(__name__)
+configure_app(app)
 
 @blueprint.route('/signin', methods=['GET', 'POST'])
 def signin():
@@ -117,10 +125,10 @@ def signin():
     if request.method == 'POST' and form.validate():
         password = form.password.data
         email = form.email.data
-        if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS__OBJECT'] and app.config['LDAP_USERNAME_PATH']):
+        if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS_OBJECT'] and app.config['LDAP_USERNAME_PATH']):
             ldap_response_object = ldap.base_connection.search(app.config['LDAP_SEARCH_OBJECT'].replace("##ACCOUNT_NAME##",email), base_dn=app.config['LDAP_BASE_SEARCH_DN'])[0]
             user = user_repo.get_by(name=ldap_response_object[app.config['LDAP_NAME_OBJECT']][0])
-            if user and ldap.base_connection.authenticate(r[app.config['LDAP_USERNAME_PATH']][0], password):
+            if user and ldap.base_connection.authenticate(ldap_response_object[app.config['LDAP_USERNAME_PATH']][0], password):
                 msg_1 = gettext("Welcome back") + " " + user.fullname
                 flash(msg_1, 'success')
                 return _sign_in_user(user)
@@ -680,3 +688,5 @@ def reset_api_key(name):
     msg = gettext('New API-KEY generated')
     flash(msg, 'success')
     return redirect(url_for('account.profile', name=name))
+
+

--- a/pybossa/view/account.py
+++ b/pybossa/view/account.py
@@ -125,20 +125,21 @@ def signin():
     if request.method == 'POST' and form.validate():
         password = form.password.data
         email = form.email.data
-        if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS_OBJECT'] and app.config['LDAP_USERNAME_PATH']):
-            ldap_response_object = ldap.base_connection.search(app.config['LDAP_SEARCH_OBJECT'].replace("##ACCOUNT_NAME##",email), base_dn=app.config['LDAP_BASE_SEARCH_DN'])[0]
-            user = user_repo.get_by(name=ldap_response_object[app.config['LDAP_NAME_OBJECT']][0])
-            if user and ldap.base_connection.authenticate(ldap_response_object[app.config['LDAP_USERNAME_PATH']][0], password):
-                msg_1 = gettext("Welcome back") + " " + user.fullname
-                flash(msg_1, 'success')
-                return _sign_in_user(user)
-            else:
-                ldap_signup(ldap_response_object)
+        try:
+            if (app.config['LDAP_SERVER'] and app.config['LDAP_CONNECTION_ACCOUNT'] and app.config['LDAP_CONNECTION_PASSWORD'] and app.config['LDAP_BASE_SEARCH_DN'] and app.config['LDAP_SEARCH_OBJECT'] and app.config['LDAP_NAME_OBJECT'] and app.config['LDAP_FULLNAME_OBJECT'] and app.config['LDAP_EMAIL_ADDRESS_OBJECT'] and app.config['LDAP_USERNAME_PATH']):
+                ldap_response_object = ldap.base_connection.search(app.config['LDAP_SEARCH_OBJECT'].replace("##ACCOUNT_NAME##",email), base_dn=app.config['LDAP_BASE_SEARCH_DN'])[0]
                 user = user_repo.get_by(name=ldap_response_object[app.config['LDAP_NAME_OBJECT']][0])
-                msg_1 = gettext("Welcome to PYBOSSA") + " " + user.fullname
-                flash(msg_1, 'success')
-                return _sign_in_user(user)
-        else:
+                if user and ldap.base_connection.authenticate(ldap_response_object[app.config['LDAP_USERNAME_PATH']][0], password):
+                    msg_1 = gettext("Welcome back") + " " + user.fullname
+                    flash(msg_1, 'success')
+                    return _sign_in_user(user)
+                else:
+                    ldap_signup(ldap_response_object)
+                    user = user_repo.get_by(name=ldap_response_object[app.config['LDAP_NAME_OBJECT']][0])
+                    msg_1 = gettext("Welcome to PYBOSSA") + " " + user.fullname
+                    flash(msg_1, 'success')
+                    return _sign_in_user(user)
+        except:
             user = user_repo.get_by(email_addr=email)
             if user and user.check_password(password):
                 msg_1 = gettext("Welcome back") + " " + user.fullname

--- a/settings_local.py.tmpl
+++ b/settings_local.py.tmpl
@@ -55,6 +55,15 @@ CONTACT_TWITTER = 'PyBossa'
 # FACEBOOK_APP_SECRET=''
 # GOOGLE_CLIENT_ID=''
 # GOOGLE_CLIENT_SECRET=''
+# LDAP_SERVER=''
+# LDAP_CONNECTION_ACCOUNT=''
+# LDAP_CONNECTION_PASSWORD=''
+# LDAP_BASE_SEARCH_DN=''
+# LDAP_SEARCH_OBJECT=''  #Your LDAP search string. Add the string ##ACCOUNT_NAME## at the location of your looked up account name
+# LDAP_NAME_OBJECT=''  #The LDAP property name you want to use as your name property
+# LDAP_FULLNAME_OBJECT=''  #The LDAP property name you want to use as your full name property
+# LDAP_EMAIL_ADDRESS_OBJECT=''  #The LDAP property name you want to use as your email property
+# LDAP_USERNAME_PATH=''  #The LDAP property name containing the absolute path to your authenticating user's user object
 
 ## Supported Languages
 

--- a/settings_local.py.tmpl
+++ b/settings_local.py.tmpl
@@ -55,15 +55,6 @@ CONTACT_TWITTER = 'PyBossa'
 # FACEBOOK_APP_SECRET=''
 # GOOGLE_CLIENT_ID=''
 # GOOGLE_CLIENT_SECRET=''
-# LDAP_SERVER=''
-# LDAP_CONNECTION_ACCOUNT=''
-# LDAP_CONNECTION_PASSWORD=''
-# LDAP_BASE_SEARCH_DN=''
-# LDAP_SEARCH_OBJECT=''  #Your LDAP search string. Add the string ##ACCOUNT_NAME## at the location of your looked up account name
-# LDAP_NAME_OBJECT=''  #The LDAP property name you want to use as your name property
-# LDAP_FULLNAME_OBJECT=''  #The LDAP property name you want to use as your full name property
-# LDAP_EMAIL_ADDRESS_OBJECT=''  #The LDAP property name you want to use as your email property
-# LDAP_USERNAME_PATH=''  #The LDAP property name containing the absolute path to your authenticating user's user object
 
 ## Supported Languages
 
@@ -160,3 +151,13 @@ ACCOUNT_CONFIRMATION_DISABLED = True
 
 # DROPBOX APP KEY
 # DROPBOX_APP_KEY = 'your-key'
+
+# LDAP_SERVER=''
+# LDAP_CONNECTION_ACCOUNT=''
+# LDAP_CONNECTION_PASSWORD=''
+# LDAP_BASE_SEARCH_DN=''
+# LDAP_SEARCH_OBJECT=''  #Your LDAP search string. Add the string ##ACCOUNT_NAME## at the location of your looked up account name
+# LDAP_NAME_OBJECT=''  #The LDAP property name you want to use as your name property
+# LDAP_FULLNAME_OBJECT=''  #The LDAP property name you want to use as your full name property
+# LDAP_EMAIL_ADDRESS_OBJECT=''  #The LDAP property name you want to use as your email property
+# LDAP_USERNAME_PATH=''  #The LDAP property name containing the absolute path to your authenticating user's user object

--- a/setup.py
+++ b/setup.py
@@ -39,7 +39,8 @@ requirements = [
     "rq-scheduler>=0.5.1, <0.5.2",
     "rq-dashboard",
     "unidecode>=0.04.16, <0.05",
-    "mailchimp"
+    "mailchimp",
+    "simpleldap"
 ]
 
 setup(


### PR DESCRIPTION
Referencing https://github.com/PyBossa/pybossa/issues/1060

I filled out the Contributor Assignment Agreement yesterday but haven't seen it come back yet, hope it's OK to submit this pull request now.

There is probably a more elegant way to expose the app config options in pybossa/view/account.py, but I'm relatively new to flask architectures. Any tweaks to this to make it smoother would be appreciated. I can confirm this is working against my org's AD infrastructure over LDAP. I haven't tested LDAPS yet.

This does introduce an application dependency on the simpleldap library.

In this code, you can:
Not define LDAP settings. You will continue using the local database for authentication
Define LDAP settings and use the local database for storage of account information, but authentication happens against your defined LDAP service.

I haven't tested enabling LDAP services combined with facebook/google/twitter options - but for organization internal use, enabling remote authentication services seems somewhat counter-intuitive.
