### PR TITLE
Issue ssl and pyrax

### DIFF
--- a/doc/install.rst
+++ b/doc/install.rst
@@ -103,7 +103,7 @@ Installing the required libraries for PyBossa is a step that will need to use
 some compilers and dev libraries in order to work. Thus, you will need to
 install the following packages::
 
-    sudo apt-get install postgresql-server-dev-9.1 python-dev swig libjpeg-dev
+    sudo apt-get install postgresql-server-dev-9.1 python-dev swig libjpeg-dev libffi-dev libssl-dev
 
 Then, you are ready to download the code and install the required libraries for
 running PyBossa.

--- a/setup.py
+++ b/setup.py
@@ -21,6 +21,9 @@ requirements = [
     "pygeoip>=0.3.1, <1.0",
     "python-dateutil>=2.2, <3.0",
     "raven>=4.1.1, <5.0",
+    "pyOpenSSL>=0.15.1, <1.0",          # fix for python below 2.7.9
+    "ndg-httpsclient>=0.4.0, <1.0",     # fix for python below 2.7.9
+    "pyasn1>=0.1.7, <1.0",              # fix for python below 2.7.9
     "requests>=2.2.1, <3.0",
     "SQLAlchemy>=0.9.6, <0.9.7",
     "six>=1.9.0, <2.0.0",
@@ -40,6 +43,8 @@ requirements = [
     "unidecode>=0.04.16, <0.05",
     "mailchimp",
     "flask-plugins"
+
+
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -43,8 +43,6 @@ requirements = [
     "unidecode>=0.04.16, <0.05",
     "mailchimp",
     "flask-plugins"
-
-
 ]
 
 setup(

--- a/setup.py
+++ b/setup.py
@@ -30,7 +30,7 @@ requirements = [
     "sphinx>=1.2.2, <2.0",
     "coverage",
     "mock",
-    "pyrax==1.8.0",
+    "pyrax==1.9.4",
     "pillow>=2.4, <2.5",
     "flask-debugtoolbar>=0.9.0, <1.0",
     "factory_boy>=2.4.1, <2.5",


### PR DESCRIPTION
Upgrade pyrax. 1.9.4 seems working great finally.

Also fix urllib3 ssl issues for python below 2.7.9 (like in Ubuntu 12.04). Details:
http://stackoverflow.com/a/29099439/756056