### PR TITLE
Cache the URL for external resources.

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -481,6 +481,7 @@ def setup_cache_timeouts(app):
     """Setup cache timeouts."""
     global timeouts
     # Apps
+    timeouts['AVATAR_TIMEOUT'] = app.config['AVATAR_TIMEOUT']
     timeouts['APP_TIMEOUT'] = app.config['APP_TIMEOUT']
     timeouts['REGISTERED_USERS_TIMEOUT'] = \
         app.config['REGISTERED_USERS_TIMEOUT']

--- a/pybossa/default_settings.py
+++ b/pybossa/default_settings.py
@@ -63,6 +63,7 @@ REDIS_KEYPREFIX = 'pybossa_cache'
 
 ## Default cache timeouts
 # Project cache
+AVATAR_TIMEOUT = 30 * 24 * 60 * 60
 APP_TIMEOUT = 15 * 60
 REGISTERED_USERS_TIMEOUT = 15 * 60
 ANON_USERS_TIMEOUT = 5 * 60 * 60

--- a/pybossa/uploader/__init__.py
+++ b/pybossa/uploader/__init__.py
@@ -25,6 +25,8 @@ This module exports:
 """
 import sys
 from PIL import Image
+from pybossa.core import timeouts
+from pybossa.cache import memoize
 
 
 class Uploader(object):
@@ -98,6 +100,7 @@ class Uploader(object):
         else:
             return False
 
+    @memoize(timeout=timeouts.get('APP_TIMEOUT'))
     def external_url_handler(self, error, endpoint, values):
         """Build up an external URL when url_for cannot build a URL."""
         # This is an example of hooking the build_error_handler.

--- a/pybossa/uploader/__init__.py
+++ b/pybossa/uploader/__init__.py
@@ -25,8 +25,6 @@ This module exports:
 """
 import sys
 from PIL import Image
-from pybossa.core import timeouts
-from pybossa.cache import memoize
 
 
 class Uploader(object):
@@ -100,7 +98,6 @@ class Uploader(object):
         else:
             return False
 
-    @memoize(timeout=timeouts.get('APP_TIMEOUT'))
     def external_url_handler(self, error, endpoint, values):
         """Build up an external URL when url_for cannot build a URL."""
         # This is an example of hooking the build_error_handler.

--- a/pybossa/uploader/rackspace.py
+++ b/pybossa/uploader/rackspace.py
@@ -97,7 +97,7 @@ class RackspaceUploader(Uploader):
         except pyrax.exceptions.UploadFailed:
             return False
 
-    @memoize(timeout=timeouts.get('APP_TIMEOUT'))
+    @memoize(timeout=timeouts.get('AVATAR_TIMEOUT'))
     def _lookup_url(self, endpoint, values):
         """Return Rackspace URL for object."""
         try:

--- a/pybossa/uploader/rackspace.py
+++ b/pybossa/uploader/rackspace.py
@@ -27,6 +27,8 @@ import pyrax
 import traceback
 import time
 from flask import current_app, url_for
+from pybossa.core import timeouts
+from pybossa.cache import memoize
 from pybossa.uploader import Uploader
 from werkzeug import secure_filename
 
@@ -95,6 +97,7 @@ class RackspaceUploader(Uploader):
         except pyrax.exceptions.UploadFailed:
             return False
 
+    @memoize(timeout=timeouts.get('APP_TIMEOUT'))
     def _lookup_url(self, endpoint, values):
         """Return Rackspace URL for object."""
         try:


### PR DESCRIPTION
This will speed up a lot all the URL handling within the CDN.