### PR TITLE
Issue 1101 completed projects

### DIFF
--- a/alembic/versions/ac115763654_remove_completed_column_from_project.py
+++ b/alembic/versions/ac115763654_remove_completed_column_from_project.py
@@ -1,0 +1,26 @@
+"""remove_completed_column_from_project
+
+Revision ID: ac115763654
+Revises: aee7291c81
+Create Date: 2015-06-17 16:22:58.251554
+
+"""
+
+# revision identifiers, used by Alembic.
+revision = 'ac115763654'
+down_revision = 'aee7291c81'
+
+from alembic import op
+import sqlalchemy as sa
+from pybossa.cache.projects import overall_progress
+
+
+def upgrade():
+    op.drop_column('project', 'completed')
+
+
+def downgrade():
+    op.add_column('project', sa.Column('completed', sa.Boolean, default=False))
+    query = 'UPDATE project SET completed=false;'
+    op.execute(query)
+    op.alter_column('project', 'completed', nullable=False)

--- a/pybossa/model/__init__.py
+++ b/pybossa/model/__init__.py
@@ -22,18 +22,9 @@ import uuid
 import requests
 
 from sqlalchemy import Text
-from sqlalchemy.orm import relationship, backref, class_mapper
+from sqlalchemy.orm import class_mapper
 from sqlalchemy.ext.mutable import Mutable
 from sqlalchemy.types import TypeDecorator
-from sqlalchemy import event
-from sqlalchemy.engine import reflection
-from sqlalchemy.schema import (
-    MetaData,
-    Table,
-    DropTable,
-    ForeignKeyConstraint,
-    DropConstraint,
-    )
 
 import logging
 from time import time

--- a/pybossa/model/project.py
+++ b/pybossa/model/project.py
@@ -117,17 +117,6 @@ class Project(db.Model, DomainObject):
         del self.info['autoimporter']
 
 
-@event.listens_for(Project, 'before_update')
-@event.listens_for(Project, 'before_insert')
-def empty_string_to_none(mapper, conn, target):
-    if target.name == '':
-        target.name = None
-    if target.short_name == '':
-        target.short_name = None
-    if target.description == '':
-        target.description = None
-
-
 @event.listens_for(Project, 'after_insert')
 def add_event(mapper, conn, target):
     """Update PyBossa feed with new project."""

--- a/pybossa/model/project.py
+++ b/pybossa/model/project.py
@@ -59,8 +59,6 @@ class Project(db.Model, DomainObject):
     hidden = Column(Integer, default=0)
     # If the project is featured
     featured = Column(Boolean, nullable=False, default=False)
-    # If the project is completed
-    completed = Column(Boolean, nullable=False, default=False)
     # If the project owner has been emailed
     contacted = Column(Boolean, nullable=False, default=False)
     #: Project owner_id

--- a/pybossa/repositories/project_repository.py
+++ b/pybossa/repositories/project_repository.py
@@ -50,6 +50,7 @@ class ProjectRepository(object):
 
     def save(self, project):
         self._validate_can_be('saved', project)
+        self._empty_strings_to_none(project)
         try:
             self.db.session.add(project)
             self.db.session.commit()
@@ -60,6 +61,7 @@ class ProjectRepository(object):
 
     def update(self, project):
         self._validate_can_be('updated', project)
+        self._empty_strings_to_none(project)
         try:
             self.db.session.merge(project)
             self.db.session.commit()
@@ -117,6 +119,14 @@ class ProjectRepository(object):
         self._validate_can_be('deleted as a Category', category, klass=Category)
         self.db.session.query(Category).filter(Category.id==category.id).delete()
         self.db.session.commit()
+
+    def _empty_strings_to_none(self, project):
+        if project.name == '':
+            project.name = None
+        if project.short_name == '':
+            project.short_name = None
+        if project.description == '':
+            project.description = None
 
     def _validate_can_be(self, action, element, klass=Project):
         if not isinstance(element, klass):


### PR DESCRIPTION
Closes #1101.
After some time, I realised that maybe the best way of solving #1101 was to simply remove the 'completed' attribute from projects. Projects has already a lot of fields that are unused, but, most importantly, we are currently not using this anywhere in the code. The way we know whether a project is complete is with the overall progress function from the projects cache module. And I believe this is a good place for it to be, I don't really consider 'completed' an attribute of a project, but a consequence of the state of its tasks and task runs, so I would not store it in the Project model class.