### PR TITLE
Remove old templates from theme

### DIFF
--- a/doc/user/tutorial.rst
+++ b/doc/user/tutorial.rst
@@ -794,25 +794,6 @@ The presenter will load one task, and you will be able to submit and save one
 answer for the current task.
 
 
-6. Check the results
---------------------
-
-In order to see the answers from the volunteers, you can open in your web
-browser the file **results.html**. The web page should show a chart pie with
-answers from the server http://crowdcrafting.org but you can modify the file
-**results.js** to poll your own server data.
-¬                                                                                    
-The results page shows the number of answers from the volunteers for a given
-task (the related photo will be shown), making easy to compare the results
-submitted by the volunteers.
-
-The results page is created using the `D3.JS library <http://d3js.org>`_.
-
-.. note::
-    You can see a demo of the results page `here
-    <http://dev.pybossa.com/app-flickrperson>`_
-
-
 Creating a tutorial for the users
 =================================
 


### PR DESCRIPTION
Removes some old templates that are no longer used and updates docs accordingly.
See PyBossa/pybossa-default-theme#87.