### PR TITLE
Add an empty default dict for info column

### DIFF
--- a/pybossa/model/user.py
+++ b/pybossa/model/user.py
@@ -60,7 +60,7 @@ class User(db.Model, DomainObject, UserMixin):
     valid_email = Column(Boolean, default=False)
     confirmation_email_sent = Column(Boolean, default=False)
     subscribed = Column(Boolean, default=True)
-    info = Column(MutableDict.as_mutable(JSON))
+    info = Column(MutableDict.as_mutable(JSON), default=dict())
 
     ## Relationships
     task_runs = relationship(TaskRun, backref='user')


### PR DESCRIPTION
Otherwise problems arise when later trying to update the info column, such as when a user updates their avatar.