### PR TITLE
Flickr improvements

### DIFF
--- a/pybossa/extensions.py
+++ b/pybossa/extensions.py
@@ -115,8 +115,8 @@ from importers import Importer
 importer = Importer()
 
 # Flickr OAuth integration for importer
-from pybossa.flickr_service import FlickrService
-flickr = FlickrService()
+from pybossa.flickr_client import FlickrClient
+flickr = FlickrClient()
 
 from flask.ext.plugins import PluginManager
 plugin_manager = PluginManager()

--- a/pybossa/flickr_client.py
+++ b/pybossa/flickr_client.py
@@ -20,7 +20,7 @@ from flask_oauthlib.client import OAuth
 import functools
 
 
-class FlickrService(object):
+class FlickrClient(object):
 
     """Class for Flickr integration."""
 

--- a/pybossa/view/flickr.py
+++ b/pybossa/view/flickr.py
@@ -16,7 +16,9 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.
 """Flickr view for PyBossa."""
-from flask import Blueprint, request, url_for, flash, redirect, session, current_app
+import json
+from flask import (Blueprint, request, url_for, flash, redirect, session,
+    current_app, Response)
 from pybossa.core import flickr
 from flask_oauthlib.client import OAuthException
 
@@ -55,3 +57,8 @@ def oauth_authorized():
     flickr_user = dict(username=resp['username'], user_nsid=resp['user_nsid'])
     flickr.save_credentials(session, flickr_token, flickr_user)
     return redirect(next_url)
+
+@blueprint.route('/albums')
+def user_albums():
+    albums = flickr.get_user_albums(session)
+    return Response(json.dumps(albums), mimetype='application/json')

--- a/pybossa/view/projects.py
+++ b/pybossa/view/projects.py
@@ -33,7 +33,7 @@ from rq import Queue
 import pybossa.sched as sched
 
 from pybossa.core import (uploader, signer, sentinel, json_exporter,
-    csv_exporter, importer, flickr)
+    csv_exporter, importer)
 from pybossa.model.project import Project
 from pybossa.model.category import Category
 from pybossa.model.task import Task
@@ -558,8 +558,6 @@ def import_task(short_name):
             template_args['available_importers'] = map(importer_wrap, all_importers)
             return render_template('/projects/task_import_options.html',
                                    **template_args)
-        if importer_type == 'flickr':
-            template_args['albums'] = flickr.get_user_albums(session)
         if importer_type == 'gdocs' and request.args.get('template'):  # pragma: no cover
             template = request.args.get('template')
             form.googledocs_url.data = template_tasks.get(template)
@@ -626,8 +624,6 @@ def setup_autoimporter(short_name):
             template_args['available_importers'] = map(wrap, all_importers)
             return render_template('projects/task_autoimport_options.html',
                                    **template_args)
-        if importer_type == 'flickr':
-            template_args['albums'] = flickr.get_user_albums(session)
     return render_template('/projects/importers/%s.html' % importer_type,
                                 **template_args)
 

--- a/test/test_autoimporter.py
+++ b/test/test_autoimporter.py
@@ -430,26 +430,3 @@ class TestAutoimporterBehaviour(web.Helper):
         login_url = '/flickr/?next=%2Fproject%2F%25E2%259C%2593project1%2Ftasks%2Fautoimporter%3Ftype%3Dflickr'
 
         assert login_url in res.data
-
-
-    @patch('pybossa.view.projects.flickr')
-    def test_flickr_autoimporter_page_shows_albums_and_revoke_access_option(
-            self, flickr):
-        flickr.get_user_albums.return_value = [{'photos': u'1',
-                                               'thumbnail_url': u'fake-url',
-                                               'id': u'my-fake-ID',
-                                               'title': u'my-fake-title'}]
-        self.register()
-        owner = user_repo.get(1)
-        project = ProjectFactory.create(owner=owner)
-        url = "/project/%s/tasks/autoimporter?type=flickr" % project.short_name
-
-        res = self.app.get(url)
-        print res.data
-        revoke_url = '/flickr/revoke-access?next=%2Fproject%2F%25E2%259C%2593project1%2Ftasks%2Fautoimporter%3Ftype%3Dflickr'
-
-        assert '1 photos' in res.data
-        assert 'src="fake-url"' in res.data
-        assert 'id="my-fake-ID"' in res.data
-        assert 'my-fake-title' in res.data
-        assert revoke_url in res.data

--- a/test/test_flickr_client.py
+++ b/test/test_flickr_client.py
@@ -17,12 +17,12 @@
 # along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.
 
 from mock import patch, MagicMock
+import json
 from flask import Response, session
 from default import flask_app
 from pybossa.flickr_client import FlickrClient
 
-class TestFlickrOauthBlueprint(object):
-
+class TestFlickrOauth(object):
 
     @patch('pybossa.view.flickr.flickr')
     def test_flickr_login_specifies_callback_and_read_permissions(self, flickr):
@@ -98,6 +98,16 @@ class TestFlickrOauthBlueprint(object):
 
         redirect.assert_called_with('http://next')
 
+
+class TestFlickrAPI(object):
+
+    @patch('pybossa.view.flickr.flickr')
+    def test_albums_endpoint_returns_user_albums_in_JSON_format(self, client):
+        albums = ['one album', 'another album']
+        client.get_user_albums.return_value = albums
+        resp = flask_app.test_client().get('/flickr/albums')
+
+        assert resp.data == json.dumps(albums), resp.data
 
 
 class TestFlickrClient(object):

--- a/test/test_flickr_client.py
+++ b/test/test_flickr_client.py
@@ -19,7 +19,7 @@
 from mock import patch, MagicMock
 from flask import Response, session
 from default import flask_app
-from pybossa.flickr_service import FlickrService
+from pybossa.flickr_client import FlickrClient
 
 class TestFlickrOauthBlueprint(object):
 
@@ -29,7 +29,7 @@ class TestFlickrOauthBlueprint(object):
         flickr.authorize.return_value = Response(302)
         flask_app.test_client().get('/flickr/')
         flickr.authorize.assert_called_with(
-            callback='/flickr/oauth-authorized',perms='read')
+            callback='/flickr/oauth-authorized', perms='read')
 
 
     def test_logout_removes_token_and_user_from_session(self):
@@ -100,17 +100,17 @@ class TestFlickrOauthBlueprint(object):
 
 
 
-class TestFlickrService(object):
+class TestFlickrClient(object):
     class Res(object):
         def __init__(self, status, data):
             self.status = status
             self.data = data
 
     def setUp(self):
-        self.flickr = FlickrService()
+        self.flickr = FlickrClient()
         self.token = {'oauth_token_secret': u'secret', 'oauth_token': u'token'}
         self.user = {'username': u'palotespaco', 'user_nsid': u'user'}
-        self.flickr = FlickrService()
+        self.flickr = FlickrClient()
         self.flickr.client = MagicMock()
         self.flickr.app = MagicMock()
 

--- a/test/test_web.py
+++ b/test/test_web.py
@@ -2893,27 +2893,6 @@ class TestWeb(web.Helper):
 
         assert login_url in res.data
 
-    @patch('pybossa.view.projects.flickr')
-    def test_flickr_importer_page_shows_albums_and_revoke_access_option(
-            self, flickr):
-        flickr.get_user_albums.return_value = [{'photos': u'1',
-                                               'thumbnail_url': u'fake-url',
-                                               'id': u'my-fake-ID',
-                                               'title': u'my-fake-title'}]
-        self.register()
-        owner = db.session.query(User).first()
-        project = ProjectFactory.create(owner=owner)
-        url = "/project/%s/tasks/import?type=flickr" % project.short_name
-
-        res = self.app.get(url)
-        revoke_url = '/flickr/revoke-access?next=%2Fproject%2F%25E2%259C%2593project1%2Ftasks%2Fimport%3Ftype%3Dflickr'
-
-        assert '1 photos' in res.data
-        assert 'src="fake-url"' in res.data
-        assert 'id="my-fake-ID"' in res.data
-        assert 'my-fake-title' in res.data
-        assert revoke_url in res.data
-
     def test_bulk_dropbox_import_works(self):
         """Test WEB bulk Dropbox import works"""
         dropbox_file_data = (u'{"bytes":286,'


### PR DESCRIPTION
This PR adds an endpoint /flickr/albums that returns the flickr albums for the current user if they've previously granted access to their Flickr account. This way this information can be retrieved from the front end without having to do the OAuth flow from there. More grained Flickr related information can be added later in a similar fasuin, e.g. individual images.

Together with the sudmodule PR (PyBossa/pybossa-default-theme#105), it keeps the same functionality that existed before.