### PR TITLE
Clean projects

### DIFF
--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -404,6 +404,7 @@ def get_non_updated_projects():
 def warn_old_project_owners():
     """E-mail the project owners not updated in the last 3 months."""
     from pybossa.core import mail, project_repo
+    from pybossa.cache.projects import clean
     from flask.ext.mail import Message
 
     projects = get_non_updated_projects()
@@ -423,6 +424,7 @@ def warn_old_project_owners():
             conn.send(msg)
             project.contacted = True
             project.published = False
+            clean(project.id)
             project_repo.update(project)
     return True
 

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -422,6 +422,7 @@ def warn_old_project_owners():
                           html=html)
             conn.send(msg)
             project.contacted = True
+            project.published = False
             project_repo.update(project)
     return True
 

--- a/pybossa/jobs.py
+++ b/pybossa/jobs.py
@@ -392,7 +392,7 @@ def get_non_updated_projects():
     from pybossa.core import db
     sql = text('''SELECT id FROM project WHERE TO_DATE(updated,
                 'YYYY-MM-DD\THH24:MI:SS.US') <= NOW() - '3 month':: INTERVAL
-               AND contacted != True LIMIT 25''')
+               AND contacted != True AND published = True LIMIT 25''')
     results = db.slave_session.execute(sql)
     projects = []
     for row in results:

--- a/test/test_jobs/test_old_projects.py
+++ b/test/test_jobs/test_old_projects.py
@@ -16,6 +16,7 @@
 # You should have received a copy of the GNU Affero General Public License
 # along with PyBossa.  If not, see <http://www.gnu.org/licenses/>.
 
+from pybossa.core import project_repo
 from pybossa.jobs import warn_old_project_owners, get_non_updated_projects
 from default import Test, with_context
 from factories import ProjectFactory
@@ -59,12 +60,15 @@ class TestOldProjects(Test):
         project = ProjectFactory.create(updated=date)
         project_id = project.id
         warn_old_project_owners()
+        project = project_repo.get(project_id)
         err_msg = "mail.connect() should be called"
         assert mail.connect.called, err_msg
         err_msg = "conn.send() should be called"
         assert send_mock.send.called, err_msg
         err_msg = "project.contacted field should be True"
         assert project.contacted, err_msg
+        err_msg = "project.published field should be False"
+        assert project.published is False, err_msg
         err_msg = "The update date should be different"
         assert project.updated != date, err_msg
 


### PR DESCRIPTION
When a project is old enough, the system removes it from publication warning the owner via email.