### PR TITLE
upgrade m2crypto, runs with newest OpenSSL and swig version

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -14,7 +14,7 @@ requirements = [
     "Flask>=0.10.1, <0.10.2",           # was pinned to Flask==0.10.1
     "html2text>=2014.4.5, <2014.9.7",
     "itsdangerous>=0.24, <1.0",
-    "M2Crypto>=0.22.3, <0.22.4",        # let's be more restrictive on M2Crypto version
+    "M2Crypto>=0.22.5, <0.22.6",        # let's be more restrictive on M2Crypto version
     "markdown>=2.4, <3.0",
     "psycopg2>=2.5.2, <3.0",
     "pygeoip>=0.3.1, <1.0",


### PR DESCRIPTION
Don't merge yet. New libs are needed of OS X support (and also next big Ubuntu upgrade in the future).