### PR TITLE
Fix depracated novaclient 1.1 dependency for pyrax by pinning python-novaclient

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -33,6 +33,7 @@ requirements = [
     "sphinx>=1.2.2, <2.0",
     "coverage",
     "mock",
+    "python-novaclient>=2.31.0, <3.0",
     "pyrax>=1.9.5, <2.0",
     "pillow>=3.0, <3.1",
     "flask-debugtoolbar>=0.9.0, <1.0",


### PR DESCRIPTION
…novaclient

See issues:
https://github.com/rackspace/pyrax/issues/544
https://github.com/rackspace/pyrax/pull/547

Since 2015-12-18 python-novaclient 3.x was released. It removed deprecated
novaclient.v1_1 which was needed by pyrax.
Pyrax needs to fix this!