### PR TITLE
Pin Flask-misaka

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -8,7 +8,7 @@ requirements = [
     "Flask-Login",                      # was pinned to Flask-Login==0.2.3 in the past. GitHub version 3.0+ is used now.
     "Flask-Mail>=0.9.0, <1.0",
     "misaka>=1.0.0, <2.0.0",
-    "Flask-Misaka>=0.2.0, <1.0",
+    "Flask-Misaka>=0.2.0, <0.4.0",
     "Flask-OAuthlib>=0.9.1, <0.9.2",
     "Flask-SQLAlchemy>=2.0, <2.1",
     "Flask-WTF>=0.9.5, <0.9.6",         # was pinned to Flask-WTF==0.9.5


### PR DESCRIPTION
Flask-misaka v0.4.0 uses the updated API from misaka v2.0.0 (which is not a PyBossa requirement), so restricting Flask-misaka to <0.4.0 to maintain compatibility.