### PR TITLE
Add hook for available plugins

### DIFF
--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -498,6 +498,9 @@ def setup_hooks(app):
             contact_twitter = app.config.get('CONTACT_TWITTER')
         else:
             contact_twitter = 'PyBossa'
+        
+        # Available plugins
+        plugins = plugin_manager.plugins.keys()
 
         return dict(
             brand=app.config['BRAND'],
@@ -515,7 +518,8 @@ def setup_hooks(app):
             contact_twitter=contact_twitter,
             upload_method=app.config['UPLOAD_METHOD'],
             news=news,
-            notify_admin=notify_admin)
+            notify_admin=notify_admin,
+            plugins=plugins)
 
 
 def setup_jinja2_filters(app):

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -500,7 +500,7 @@ def setup_hooks(app):
             contact_twitter = 'PyBossa'
 
         # Available plugins
-        plugins = plugin_manager.plugins.values()
+        plugins = plugin_manager.plugins
 
         return dict(
             brand=app.config['BRAND'],

--- a/pybossa/core.py
+++ b/pybossa/core.py
@@ -498,9 +498,9 @@ def setup_hooks(app):
             contact_twitter = app.config.get('CONTACT_TWITTER')
         else:
             contact_twitter = 'PyBossa'
-        
+
         # Available plugins
-        plugins = plugin_manager.plugins.keys()
+        plugins = plugin_manager.plugins.values()
 
         return dict(
             brand=app.config['BRAND'],


### PR DESCRIPTION
This provides a hook for a list of plugins available on the server.

I'm redesigning some PyBossa plugins, along with a theme, and I'm trying to make everything as modular as possible. By providing this variable we can write a theme that doesn't rely on a plugin but will make use of it if available. For example, we can put something like this in our templates:

```
{% if 'pybossa_plugin' in plugins %}
    <a href="{{ url_for('plugin.index') }}">Some Plugin</a>
{% endif %}
```

Otherwise, we can either not use `url_for` and accept a broken link, or use `url_for` and have the page crash, if for some reason the plugin isn't available. What do you think?