### PR TITLE
upgrade m2crypto

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -15,7 +15,7 @@ requirements = [
     "Flask>=0.10.1, <0.10.2",           # was pinned to Flask==0.10.1
     "html2text>=2014.4.5, <2014.9.7",
     "itsdangerous>=0.24, <1.0",
-    "M2Crypto>=0.22.3, <0.22.4",        # let's be more restrictive on M2Crypto version
+    "M2Crypto>=0.24.0, <0.24.1",        # let's be more restrictive on M2Crypto version
     "markdown>=2.4, <3.0",
     "psycopg2>=2.5.2, <3.0",
     "pygeoip>=0.3.1, <1.0",


### PR DESCRIPTION
m2crypto old versions has compatibility issues with new Openssl versions.
The newest m2crypto compiles flawless.