### PR TITLE
Update task.state when redundancy is changed.

### DIFF
--- a/pybossa/api/api_base.py
+++ b/pybossa/api/api_base.py
@@ -300,6 +300,7 @@ class APIBase(MethodView):
         old = self.__class__(**existing.dictize())
         for key in data:
             setattr(existing, key, data[key])
+        self._update_attribute(existing, old)
         update_func = repos[self.__class__.__name__]['update']
         self._validate_instance(existing)
         getattr(repo, update_func)(existing)
@@ -314,6 +315,13 @@ class APIBase(MethodView):
 
         """
         pass
+
+    def _update_attribute(self, new, old):
+        """Update object attribute if new value is passed.
+        Method to be overriden in inheriting classes which wish to update
+        data dict.
+
+        """
 
     def _select_attributes(self, item_data):
         """Method to be overriden in inheriting classes in case it is not

--- a/pybossa/api/task.py
+++ b/pybossa/api/task.py
@@ -40,3 +40,7 @@ class TaskAPI(APIBase):
         for key in data.keys():
             if key in self.reserved_keys:
                 raise BadRequest("Reserved keys in payload")
+
+    def _update_attribute(self, new, old):
+        if (new.state == 'completed') and (old.n_answers <= new.n_answers):
+            new.state = 'ongoing'

--- a/test/test_api/test_task_api.py
+++ b/test/test_api/test_task_api.py
@@ -442,7 +442,17 @@ class TestTaskAPI(TestAPI):
         task.state = 'completed'
         task_repo.update(task)
 
-        data = {'n_answers': 3}
+        data = {'n_answers': 1}
+        datajson = json.dumps(data)
+
+        res = self.app.put(url, data=datajson)
+        out = json.loads(res.data)
+        assert_equal(res.status, '200 OK', res.data)
+        assert_equal(task.n_answers, data['n_answers'])
+        assert_equal(task.state, 'completed')
+        assert task.id == out['id'], out
+
+        data = {'n_answers': 5}
         datajson = json.dumps(data)
 
         res = self.app.put(url, data=datajson)

--- a/test/test_api/test_task_api.py
+++ b/test/test_api/test_task_api.py
@@ -383,6 +383,7 @@ class TestTaskAPI(TestAPI):
         out = json.loads(res.data)
         assert_equal(res.status, '200 OK', res.data)
         assert_equal(task.n_answers, data['n_answers'])
+        assert_equal(task.state, 'ongoing')
         assert task.id == out['id'], out
 
         ### root
@@ -390,6 +391,7 @@ class TestTaskAPI(TestAPI):
                            data=root_datajson)
         assert_equal(res.status, '200 OK', res.data)
         assert_equal(root_task.n_answers, root_data['n_answers'])
+        assert_equal(task.state, 'ongoing')
 
         # PUT with not JSON data
         res = self.app.put(url, data=data)
@@ -418,6 +420,37 @@ class TestTaskAPI(TestAPI):
         assert err['target'] == 'task', err
         assert err['action'] == 'PUT', err
         assert err['exception_cls'] == 'TypeError', err
+
+    @with_context
+    def test_task_update_state(self):
+        """Test API task n_answers updates state properly."""
+        user = UserFactory.create()
+        project = ProjectFactory.create(owner=user)
+        task = TaskFactory.create(project=project, n_answers=1,
+                                  state='ongoing')
+        data = {'n_answers': 2}
+        datajson = json.dumps(data)
+
+        url = '/api/task/%s?api_key=%s' % (task.id, user.api_key)
+        res = self.app.put(url, data=datajson)
+        out = json.loads(res.data)
+        assert_equal(res.status, '200 OK', res.data)
+        assert_equal(task.n_answers, data['n_answers'])
+        assert_equal(task.state, 'ongoing')
+        assert task.id == out['id'], out
+
+        task.state = 'completed'
+        task_repo.update(task)
+
+        data = {'n_answers': 3}
+        datajson = json.dumps(data)
+
+        res = self.app.put(url, data=datajson)
+        out = json.loads(res.data)
+        assert_equal(res.status, '200 OK', res.data)
+        assert_equal(task.n_answers, data['n_answers'])
+        assert_equal(task.state, 'ongoing')
+        assert task.id == out['id'], out
 
 
     @with_context


### PR DESCRIPTION
When a task has been completed, and the redundancy is increased,
then that task should be put into the pool again. This Commit fixes this
issue.